### PR TITLE
Revert the vulnerability fix for graal-sdk 

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -38,6 +38,7 @@
         <quarkus.operator.sdk.version>6.0.1</quarkus.operator.sdk.version>
         <quarkus.operator.build.version>3.0.0.Final</quarkus.operator.build.version>
         <quarkus.container-image.group>keycloak</quarkus.container-image.group>
+        <graal-sdk.version>22.3.2</graal-sdk.version>
     </properties>
     
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
 
         <quarkus.version>3.1.0.Final</quarkus.version>
         <quarkus.build.version>3.0.3.Final</quarkus.build.version>
-        <graal-sdk.version>22.3.2</graal-sdk.version>
 
         <project.build-time>${timestamp}</project.build-time>
 

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -21,16 +21,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.graalvm.sdk</groupId>
-                    <artifactId>graal-sdk</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -55,11 +55,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.graalvm.sdk</groupId>
-                <artifactId>graal-sdk</artifactId>
-                <version>${graal-sdk.version}</version>
-            </dependency>
             
             <!-- Override the dependencies below to use the versions used by Keycloak -->
             <dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -67,16 +67,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.graalvm.sdk</groupId>
-                    <artifactId>graal-sdk</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -62,16 +62,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.graalvm.sdk</groupId>
-                    <artifactId>graal-sdk</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Revert the fix for https://security.snyk.io/vuln/SNYK-JAVA-ORGGRAALVMSDK-5457933, vulnerability is fixed after upgrading to Quarkus 3.1.0.Final

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
